### PR TITLE
Potential fix for code scanning alert no. 5: Potentially uninitialized local variable

### DIFF
--- a/src/backup.py
+++ b/src/backup.py
@@ -519,6 +519,7 @@ def setup_scheduler(schedule_config):
     except ZoneInfoNotFoundError:
         logger.warning(f"无效时区: {timezone_str}，回退到 Asia/Shanghai")
         tz = ZoneInfo("Asia/Shanghai")
+    now = datetime.now(tz)
 
     def scheduled_task():
         logger.info("开始执行定时备份任务...")


### PR DESCRIPTION
Potential fix for [https://github.com/freemankevin/nacos-backup/security/code-scanning/5](https://github.com/freemankevin/nacos-backup/security/code-scanning/5)

To fix the issue, we need to ensure that the `now` variable is always initialized before it is used. The best approach is to initialize `now` at the beginning of the `setup_scheduler` function, as it is used in both the `if cron_expr` and `elif interval` blocks. This ensures that `now` is always available regardless of which condition is met.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
